### PR TITLE
Improve docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,9 +27,7 @@ services:
       - ./database:/docker-entrypoint-initdb.d
 
   restape:
-    build:
-      context: ./RestAPE
-    image: rest-ape
+    image: ghcr.io/sanctuuary/restape:latest
     restart: always
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - "${WF_DATA_DIR}/postgres_data:/var/lib/postgresql/data"
+      - ./database:/docker-entrypoint-initdb.d
 
   restape:
     build:


### PR DESCRIPTION
### Description

Made two changes to the docker compose. The first makes postgres image initialize the database with the `.sql` scripts automatically, and the second uses the restape image created in https://github.com/sanctuuary/restape/pull/12. This should work after the images are being built, and are made public.