### PR TITLE
Use the new workflow property in benchmarks and change circle to be a square

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -40,6 +40,7 @@
   -webkit-backface-visibility: hidden; /* Safari */
   backface-visibility: hidden;
   background-color: white; /* On mozilla, this needs to be opaque or the front side will show on the back side */
+  overflow: auto;
 }
 
 /* Put the content of the back side on the back side */

--- a/src/App.css
+++ b/src/App.css
@@ -52,6 +52,10 @@
   font-size: 0; /* Remove whitespace between inline-block elements */
 }
 
+.divided {
+  display: flex;
+  align-items: center;
+}
 .circle-filled {
   display: inline-block;
   width: 12px;
@@ -59,6 +63,7 @@
   background-color: #7bd310; /* Filled circle color */
   border-radius: 50%;
   margin-right: 5px; /* Spacing between circles */
+  border: 1px solid #7bd310; /* Border color to have the same size as the empty version */
 }
 
 .circle-empty {
@@ -68,4 +73,25 @@
   border: 1px solid #7bd310; /* Border color to represent an empty circle */
   border-radius: 50%;
   margin-right: 5px; /* Spacing between circles */
+}
+
+.square-filled {
+  display: flex;
+  width: 12px;
+  height: 12px;
+  background-color: #7bd310; /* Filled square color */
+  border: 1px solid #7bd310; /* Border color to have the same size as the empty version */
+}
+
+.square-empty {
+  display: flex;
+  width: 12px;
+  height: 12px;
+  border: 1px solid #7bd310; /* Border color to represent an empty square */
+}
+
+.connect-squares {
+  flex-grow: 1;
+  width: 7px;
+  border-bottom: 1px solid black;
 }

--- a/src/components/benchmark/VisualizeBenchmarks.tsx
+++ b/src/components/benchmark/VisualizeBenchmarks.tsx
@@ -28,10 +28,10 @@ const VisualizeBenchmark: React.FC<any> = observer((props) => {
     const availability = Math.floor(Math.random() * 100);
     const executedSteps = Math.floor(Math.random() * (workflow.workflow_length + 1));
     benchmarkValues[workflow.name] = {
-      '1': {value: workflow.workflow_length, desirabilityValue: (workflow.workflow_length / 10.0)} as BenchmarkValue,
-      '2': {value: executedSteps, desirabilityValue: (executedSteps) / workflow.workflow_length} as BenchmarkValue,
-      '3': {value: n_proteins, desirabilityValue: 0.01 * n_proteins} as BenchmarkValue,
-      '4': {value: availability, desirabilityValue: 0.01 * availability} as BenchmarkValue
+      '1': {description: "Sample desc 1", value: workflow.workflow_length, desirability_value: (workflow.workflow_length / 10.0)} as BenchmarkValue,
+      '2': {description: "Sample desc 2", value: executedSteps, desirability_value: (executedSteps) / workflow.workflow_length} as BenchmarkValue,
+      '3': {description: "Sample desc 3", value: n_proteins, desirability_value: 0.01 * n_proteins} as BenchmarkValue,
+      '4': {description: "Sample desc 4", value: availability, desirability_value: 0.01 * availability} as BenchmarkValue
     };
   });
 
@@ -52,7 +52,7 @@ const VisualizeBenchmark: React.FC<any> = observer((props) => {
               { benchmarks.map(benchmark => {
                 const key = `${workflow.name}-${benchmark.id}`;
                 const bmValue: BenchmarkValue = benchmarkValues[workflow.name][benchmark.id];
-                const color = mapValueToColor(bmValue.desirabilityValue);
+                const color = mapValueToColor(bmValue.desirability_value);
                 return (<td key={key} style={{backgroundColor: color}}>{bmValue.value.toString()}</td>);
               })}
             </tr>

--- a/src/components/explore/GenerationResults.tsx
+++ b/src/components/explore/GenerationResults.tsx
@@ -75,11 +75,33 @@ const GenerationResults: React.FC<any> = observer((props) => {
       const val = parseInt(value[0]);
       const maxVal = parseInt(value[2]);
       return (<div className="star-rating">
-        {[...Array(val)].map((e, i) => <span key={i} className="circle-filled">O</span>)}
-        {[...Array(maxVal-val)].map((e, i) => <span key={i} className="circle-empty">x</span>)}
+        {[...Array(val)].map((e, i) => [<span key={i} className="circle-filled"></span>])}
+        {[...Array(maxVal-val)].map((e, i) => <span key={i} className="circle-empty"></span>)}
       </div>);
     }
     return null;
+  };
+  const getRating = (benchmark: TechBenchmarkValue) => {
+    if (typeof benchmark.workflow === 'undefined') {
+      if (typeof benchmark.value === 'string') {
+        return <div className="flex gap-4 m-1 items-center">{benchmark.value} {getStars(benchmark.value)}</div>;
+      }
+      console.error("Unexpected benchmark.value type", typeof benchmark.value, benchmark);
+      return null;
+    } else {
+      const maxVal = benchmark.workflow.length;
+      const val = benchmark.workflow.reduce((acc, cur) => acc + cur.desirability_value, 0).toString();
+      const rating = `${val}/${maxVal}`
+
+      return (<div className="flex gap-4 m-1 items-center">{rating}<div className="divided">
+                  {benchmark.workflow.map((e, i) => 
+                  [
+                    <span key={i} className={"square-" + (e.desirability_value === 1 ? 'filled' : "empty")}> </span>,
+                    i + 1 < benchmark.workflow.length ? <span className="connect-squares"></span> : null
+                  ])}
+                </div>
+              </div>);
+    }
   };
 
   return (
@@ -147,7 +169,7 @@ const GenerationResults: React.FC<any> = observer((props) => {
                                   {solution.benchmarkData !== undefined && solution.benchmarkData.benchmarks.map((benchmark: TechBenchmarkValue) => (
                                     <tr key={benchmark.benchmark_title}>
                                       <td style={{ textAlign: 'left' }}>{benchmark.benchmark_title}</td>
-                                      <td style={{ textAlign: 'right' }}><div className="flex gap-4 m-1 items-center">{benchmark.value} {typeof benchmark.value === 'string' ? getStars(benchmark.value) : ''}</div></td>
+                                      <td style={{ textAlign: 'right' }}>{getRating(benchmark)}</td>
                                     </tr>
                                   ))}
                                 </tbody>

--- a/src/stores/BenchmarkTypes.ts
+++ b/src/stores/BenchmarkTypes.ts
@@ -8,6 +8,7 @@ export type TechBenchmarkValue = {
   benchmark_description: string,
   value: string | number | boolean,
   desirability_value: number,
+  workflow: BenchmarkValue[],
 }
 
 export type TechBenchmarks = {
@@ -28,8 +29,9 @@ export type Benchmark = {
 }
 
 export type BenchmarkValue = {
+  description: string,
   value: string | number | boolean,
-  desirabilityValue: number,  // A number between 0 and 1 that will be used to calculate the color
+  desirability_value: number,  // A number between 0 and 1 that will be used to calculate the color
 }
 
 export interface BenchmarkTable {
@@ -83,16 +85,16 @@ const sampleBenchmarks: Benchmark[] = [{
 
 const sampleBenchmarkTable: BenchmarkTable = {
   [sampleWorkflows[0].run_id]: { 
-    [sampleBenchmarks[0].id]: {value: 3, desirabilityValue: 0.3},
-    [sampleBenchmarks[1].id]: {value: 3, desirabilityValue: 1.0},
-    [sampleBenchmarks[2].id]: {value: 42, desirabilityValue: 0.42},
-    [sampleBenchmarks[3].id]: {value: 87, desirabilityValue: 1.0}
+    [sampleBenchmarks[0].id]: {description: "Sample desc 1", value: 3, desirability_value: 0.3},
+    [sampleBenchmarks[1].id]: {description: "Sample desc 2", value: 3, desirability_value: 1.0},
+    [sampleBenchmarks[2].id]: {description: "Sample desc 3", value: 42, desirability_value: 0.42},
+    [sampleBenchmarks[3].id]: {description: "Sample desc 4", value: 87, desirability_value: 1.0}
   },
   [sampleWorkflows[1].run_id]: {
-    [sampleBenchmarks[0].id]: {value: 8, desirabilityValue: 0.8},
-    [sampleBenchmarks[1].id]: {value: 4, desirabilityValue: 0.5},
-    [sampleBenchmarks[2].id]: {value: 0, desirabilityValue: 0.0},
-    [sampleBenchmarks[3].id]: {value: 50, desirabilityValue: 0.5}
+    [sampleBenchmarks[0].id]: {description: "Sample desc 5", value: 8, desirability_value: 0.8},
+    [sampleBenchmarks[1].id]: {description: "Sample desc 6", value: 4, desirability_value: 0.5},
+    [sampleBenchmarks[2].id]: {description: "Sample desc 7", value: 0, desirability_value: 0.0},
+    [sampleBenchmarks[3].id]: {description: "Sample desc 8", value: 50, desirability_value: 0.5}
   }
 };
 


### PR DESCRIPTION
### Description

Changed circles to squares, and added a line connecting them, so they indicate a tool in the workflow based on the new JSON structure as seen below.

Also made the images scroll when they are larger than the containing element.
![image](https://github.com/Workflomics/workflomics-frontend/assets/93575941/0182449f-e14e-4a73-a9b6-2e0157c902be)


```json
{
  "workflowName": "workflowSolution_0",
  "runID": "58259f3bbc1698794230659",
  "benchmarks": [
    {
      "benchmark_long_title": "Available in bio.tools",
      "workflow": [
        {
          "description": "Comet",
          "value": "available",
          "desirability_value": 1
        },
        {
          "description": "idconvert",
          "value": "available",
          "desirability_value": 1
        },
        {
          "description": "mzRecal",
          "value": "available",
          "desirability_value": 1
        },
        {
          "description": "Comet",
          "value": "available",
          "desirability_value": 1
        },
        {
          "description": "ProteinProphet",
          "value": "available",
          "desirability_value": 1
        }
      ],
      "benchmark_description": "Number of tools annotated in bio.tools.",
      "benchmark_title": "bio.tool",
      "value": "5/5",
      "desirability_value": "1.0"
    },
    {
      "benchmark_long_title": "Tools with a license",
      "benchmark_description": "Number of tools which have a license specified.",
      "benchmark_title": "Licensed",
      "value": "5/5",
      "desirability_value": "1.0"
    },
    {
      "benchmark_long_title": "Linux (OS) supported tools",
      "benchmark_description": "Number of tools which support Linux OS.",
      "benchmark_title": "Linux",
      "value": "5/5",
      "desirability_value": "1.0"
    },
    {
      "benchmark_long_title": "Mac OS supported tools",
      "benchmark_description": "Number of tools which support Mac OS.",
      "benchmark_title": "Mac OS",
      "value": "4/5",
      "desirability_value": "0.8"
    },
    {
      "benchmark_long_title": "Windows (OS) supported tools",
      "benchmark_description": "Number of tools which support Windows OS.",
      "benchmark_title": "Windows",
      "value": "2/5",
      "desirability_value": "0.4"
    }
  ],
  "domainID": "1"
}
```