### PR TITLE
Add tooltips to squares and benchmark titles

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -81,6 +81,7 @@
   width: 12px;
   height: 12px;
   border: 1px solid black; /* Border color to have the same size as the empty version */
+  border-radius: 20%;
 }
 
 .square-filled {

--- a/src/App.css
+++ b/src/App.css
@@ -76,19 +76,15 @@
   margin-right: 5px; /* Spacing between circles */
 }
 
-.square-filled {
+.square {
   display: flex;
   width: 12px;
   height: 12px;
-  background-color: #7bd310; /* Filled square color */
   border: 1px solid black; /* Border color to have the same size as the empty version */
 }
 
-.square-empty {
-  display: flex;
-  width: 12px;
-  height: 12px;
-  border: 1px solid black; /* Border color to represent an empty square */
+.square-filled {
+  background-color: #7bd310; /* Filled square color */
 }
 
 .connect-squares {

--- a/src/App.css
+++ b/src/App.css
@@ -81,14 +81,14 @@
   width: 12px;
   height: 12px;
   background-color: #7bd310; /* Filled square color */
-  border: 1px solid #7bd310; /* Border color to have the same size as the empty version */
+  border: 1px solid black; /* Border color to have the same size as the empty version */
 }
 
 .square-empty {
   display: flex;
   width: 12px;
   height: 12px;
-  border: 1px solid #7bd310; /* Border color to represent an empty square */
+  border: 1px solid black; /* Border color to represent an empty square */
 }
 
 .connect-squares {

--- a/src/components/explore/GenerationResults.tsx
+++ b/src/components/explore/GenerationResults.tsx
@@ -96,7 +96,7 @@ const GenerationResults: React.FC<any> = observer((props) => {
       return (<div className="flex gap-4 m-1 items-center">{rating}<div className="divided">
                   {benchmark.workflow.map((e, i) => 
                   [
-                    <span key={i} className={"square-" + (e.desirability_value === 1 ? 'filled' : "empty")}> </span>,
+                    <span key={i} className={"square " + (e.desirability_value === 1 ? "square-filled" : "")}> </span>,
                     i + 1 < benchmark.workflow.length ? <span className="connect-squares"></span> : null
                   ])}
                 </div>

--- a/src/components/explore/GenerationResults.tsx
+++ b/src/components/explore/GenerationResults.tsx
@@ -96,7 +96,7 @@ const GenerationResults: React.FC<any> = observer((props) => {
       return (<div className="flex gap-4 m-1 items-center">{rating}<div className="divided">
                   {benchmark.workflow.map((e, i) => 
                   [
-                    <span key={i} className={"square " + (e.desirability_value === 1 ? "square-filled" : "")}> </span>,
+                    <span key={i} className={"tooltip square " + (e.desirability_value === 1 ? "square-filled" : "")} data-tip={e.description}> </span>,
                     i + 1 < benchmark.workflow.length ? <span className="connect-squares"></span> : null
                   ])}
                 </div>
@@ -168,7 +168,7 @@ const GenerationResults: React.FC<any> = observer((props) => {
                                   </tr>
                                   {solution.benchmarkData !== undefined && solution.benchmarkData.benchmarks.map((benchmark: TechBenchmarkValue) => (
                                     <tr key={benchmark.benchmark_title}>
-                                      <td style={{ textAlign: 'left' }}>{benchmark.benchmark_title}</td>
+                                      <td style={{ textAlign: 'left' }} className="tooltip" data-tip={benchmark.benchmark_long_title}>{benchmark.benchmark_title}</td>
                                       <td style={{ textAlign: 'right' }}>{getRating(benchmark)}</td>
                                     </tr>
                                   ))}


### PR DESCRIPTION
### Description

Added tooltips to squares and benchmark items' title.

**NB**. It should be merged after #22.

![image](https://github.com/Workflomics/workflomics-frontend/assets/93575941/422a1f55-234f-4deb-8330-b9a9cdcc6cdc)
