### PR TITLE
Pin postgres version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     depends_on:
       - db
   db:
-    image: postgres
+    image: postgres:15
     restart: always
     ports:
       - "5432:5432"


### PR DESCRIPTION
### Description
If the version is not pinned, there might be issues when the major version changes automatically, so it's better to pin it.