### PR TITLE
Add tooltips and improve layout of the synthesis results page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Workflomics_frontend",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "dependencies": {
     "@mdi/js": "^7.3.67",

--- a/src/components/explore/GenerationResults.tsx
+++ b/src/components/explore/GenerationResults.tsx
@@ -242,10 +242,19 @@ const GenerationResults: React.FC<any> = observer((props) => {
               </div>
             </div>
 
-          <div className="flex justify-left gap-2 mt-8">
-              <button className="btn btn-primary" onClick={() => downloadSelectedWorkflows()}>Download <br/> selected</button>
-              <button className="btn btn-primary" onClick={() => downloadInputFile(workflowSolutions[0].run_id)}>Download <br/>CWL input file</button>
-              <button className="btn btn-primary" onClick={() => compareSelected()}>Compare executed<br/> workflows</button>
+            <div className="flex justify-between gap-2 mt-8">
+              <div className="flex justify-left gap-2">
+                <div className="tooltip tooltip-right" data-tip="Download a zip file containing the selected CWLs and instructions how to run them.">
+                  <button className="btn btn-primary" onClick={() => downloadSelectedWorkflows()}>Download <br /> selected</button>
+                </div>
+                <div className="tooltip tooltip-right" data-tip="Download the CWL input file.">
+                  <button className="btn btn-primary" onClick={() => downloadInputFile(workflowSolutions[0].run_id)}>Download <br />CWL input file</button>
+                </div>
+                </div>
+                <div className="tooltip tooltip-left" data-tip="Go to the page to upload the run-time benchmarks.">
+                  <button className="btn btn-primary" onClick={() => compareSelected()}>Upload benchmarked<br /> workflows</button>
+                </div>
+              
             </div>
           </div>
 


### PR DESCRIPTION
Just a small fix to the tooltips and the layout. Moved the "Upload benchmarks" to the right
<img width="1376" alt="Screenshot 2024-02-19 at 11 18 06" src="https://github.com/Workflomics/workflomics-frontend/assets/11068408/eecbc8f5-4f02-4cd3-8303-4230b149b64c">

In addition, the version was updated.
