### PR TITLE
Replace "My Workflows" with the "User Guide"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "Workflomics_frontend",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "Workflomics_frontend",
-      "version": "0.2.0",
+      "version": "1.0.0",
       "dependencies": {
         "@mdi/js": "^7.3.67",
         "@mdi/react": "^1.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Workflomics_frontend",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "private": true,
   "dependencies": {
     "@mdi/js": "^7.3.67",

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -8,10 +8,10 @@ const Home: FC = () => {
 
   return (
     <div>
-      <div className="flex space-x-7 p-11">
+      <div className="flex space-x-7 p-11 justify-center">
         <HomeBox label="Generate workflow" descr="Generation of workflows" imgUrl={generate_img} buttonText="Explore" isEnabled={true} component="/explore/domain" />
         <HomeBox label="Benchmark workflows" descr="Evaluate the quality of your workflows" imgUrl={benchmark_img} buttonText="Benchmark" isEnabled={true} component="/benchmark/visualize" />
-        <HomeBox label="My workflows" descr="Explore discovered and uploaded workflows" imgUrl={history_img} buttonText="Workflows" isEnabled={true} component="/" />
+        <HomeBox label="How to use Workflomics?" descr="Explore the Workflomics documentation" imgUrl={history_img} buttonText="User Guide" isEnabled={true} component="https://workflomics.readthedocs.io/en/latest/user-guide/web-interface.html" />
       </div>
     </div>
 

--- a/src/components/Home.tsx
+++ b/src/components/Home.tsx
@@ -9,8 +9,8 @@ const Home: FC = () => {
   return (
     <div>
       <div className="flex space-x-7 p-11 justify-center">
-        <HomeBox label="Generate workflow" descr="Generation of workflows" imgUrl={generate_img} buttonText="Explore" isEnabled={true} component="/explore/domain" />
-        <HomeBox label="Benchmark workflows" descr="Evaluate the quality of your workflows" imgUrl={benchmark_img} buttonText="Benchmark" isEnabled={true} component="/benchmark/visualize" />
+        <HomeBox label="Generate workflow" descr="Explore bioinformatics workflows generated according to your description" imgUrl={generate_img} buttonText="Explore" isEnabled={true} component="/explore/domain" />
+        <HomeBox label="Visualize benchmarks" descr="Upload and visualize the benchmarks performed locally" imgUrl={benchmark_img} buttonText="Benchmark" isEnabled={true} component="/benchmark/visualize" />
         <HomeBox label="How to use Workflomics?" descr="Explore the Workflomics documentation" imgUrl={history_img} buttonText="User Guide" isEnabled={true} component="https://workflomics.readthedocs.io/en/latest/user-guide/web-interface.html" />
       </div>
     </div>

--- a/src/components/explore/GenerationConfig.tsx
+++ b/src/components/explore/GenerationConfig.tsx
@@ -61,7 +61,7 @@ const GenerationConfig: React.FC<any> = observer((props) => {
               </div>
                     <div className="flex items-center m-2 tooltip tooltip-bottom"
                       data-tip="Specify desired number of workflows that satisfy the specification.">
-                  <label className="w-80 text-lg">Number of solutions (max)</label>
+                  <label className="w-80 text-lg">Number of workflows (max)</label>
                 <input
                   type="number"
                   className="input input-bordered w-full max-w-xs"


### PR DESCRIPTION
A small change that replaced the "My Workflows" button on the Home page, which did not have a functionality, with the "User Guide" button, which leads to the web interface user guide on ReadtheDocs. The button does not open a new tab, as I did not find a straightforward way to do so.

I also updated the descriptions and centred the 3 divs, as they were left aligned. 


The new interface:
![Screenshot 2024-05-23 at 17 05 53](https://github.com/Workflomics/workflomics-frontend/assets/11068408/22af42c5-b856-43b4-ac29-1bdd3dde6383)


