### PR TITLE
This commit fixes syntax errors that were introduced by removing line…

### DIFF
--- a/database/03_import_data.sql
+++ b/database/03_import_data.sql
@@ -1,5 +1,6 @@
 INSERT INTO public."domain" (id,unique_label,repo_url,tool_annotations_file_name,ontology_file_name,docker_image_url,public) VALUES
-	 (1,'proteomics','https://raw.githubusercontent.com/Workflomics/domain-annotations/main/WombatP_tools/config.json','bio.tools_proteomics_domain.json','edam.owl',NULL,true),
+	 (1,'proteomics','https://raw.githubusercontent.com/Workflomics/domain-annotations/main/WombatP_tools/config.json','bio.tools_proteomics_domain.json','edam.owl',NULL,true);
+
 INSERT INTO public."permission" (id,unique_label,permission_level,description) VALUES
 	 (1,'generate_workflows',0,'User can browse public domains and generate workflows.'),
 	 (2,'control_personal_history',1,'The user can create and edit personal history.'),
@@ -9,19 +10,23 @@ INSERT INTO public."permission" (id,unique_label,permission_level,description) V
 	 (6,'admin_domains',1000,'User can edit any domain on the platform.'),
 	 (7,'admin_users',1000,'User can edit user data of other users.'),
 	 (8,'execute_workflows',100,'User can access the provided benchmarking cloud services to benchmark workflows');
+
 INSERT INTO public.topic_of_research (id,unique_label,description,permission_id_required) VALUES
 	 (1,'official','A tag that only administrators are allowed to add to a repository.',6),
 	 (2,'omics',NULL,5),
 	 (3,'metabolomics',NULL,5),
 	 (4,'proteomics',NULL,5);
+
 INSERT INTO public.domain_topics (domain_id,topic_id) VALUES
 	 (1,1),
 	 (1,2),
-	 (1,4),
+	 (1,4);
+
 INSERT INTO public."role" (id,unique_label,description) VALUES
 	 (1,'user','A user that can generate workflows, browse history of generated workflows and upload and visualise benchmarking results'),
 	 (2,'admin','User that has full access to the platform.'),
 	 (3,'curator','User that can be associated with domains and modify them.');
+
 INSERT INTO public.role_permission (id,role_id_fk,permission_id_fk) VALUES
 	 (1,1,3),
 	 (2,1,2),
@@ -33,6 +38,7 @@ INSERT INTO public.role_permission (id,role_id_fk,permission_id_fk) VALUES
 	 (8,3,5),
 	 (9,2,1),
 	 (10,2,2);
+
 INSERT INTO public.role_permission (id,role_id_fk,permission_id_fk) VALUES
 	 (11,2,3),
 	 (12,2,4),


### PR DESCRIPTION
…s in a way that the queries were not ended by a semicolon.

# Overview
<!-- Briefly describe what this PR does. -->

This PR fixes #87 by replacing wrongly set colons by semicolons.

## Changes
<!-- List the main changes in this PR. -->

The PR replaces the trailing colon of the insertions into `domain` and `domain_topics` with a semicolon.
Also, a blank line is inserted between each two queries to make the SQL script more readable.

## Testing
<!-- Describe how you tested your changes. -->

The changes were tested in a docker setup.

## Checklist

- [ ] Code follows project standards.
- [ ] Self-reviewed and commented where needed.
- [ ] Documentation updated if needed.
- [ ] No new warnings or errors.