### PR TITLE
Add new domain issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-domain-request.md
+++ b/.github/ISSUE_TEMPLATE/new-domain-request.md
@@ -1,0 +1,29 @@
+---
+name: New Domain Integration
+about: Request the addition of a new domain to the Workflomics platform
+title: '[DOMAIN] Add domain: '
+labels: 'enhancement'
+assignees: ''
+
+---
+
+## Domain Name
+<!-- Provide the full name of the domain. -->
+
+## Description
+<!-- Short description of the domain and its purpose. -->
+
+## Domain Config
+<!-- Link to the domain's config.json file (publicly accessible). -->
+[config.json](https://...)
+
+## Validation
+- [ ] I have validated the domain locally using the Workflomics CLI or web interface.
+- [ ] All referenced tools and types are accessible and properly configured.
+
+## Notes
+<!-- Any other relevant information for reviewers. -->
+
+## Next Steps
+- [ ] Update the SQL database using the provided script after approval.
+- [ ] Confirm successful integration in the Workflomics platform after deployment.


### PR DESCRIPTION
Our documentation requires new. users to open an issue to add a new domain to the live Workflomics version. This is an attempt to simplify that step.