### PR TITLE
Implement a filter that removes all plain taxonomy class entries

### DIFF
--- a/src/stores/TaxStore.ts
+++ b/src/stores/TaxStore.ts
@@ -80,7 +80,7 @@ export class TaxStore {
       else {
         const taxMap: ApeTaxTuple = {};
         for (let dataTax of resultData) {
-          taxMap[dataTax.id] = dataTax;
+          taxMap[dataTax.id] = this.cleanTaxonomyClass(dataTax);
         }
         this.availableDataTax = taxMap;
       }
@@ -124,6 +124,33 @@ export class TaxStore {
     }
     return undefined;
   };
+
+  /**
+   * Removes entries from the taxonomy class which are invalid for the UI.
+   * Currently, those are plain taxonomy entries, i.e. the ones with label ending with "_p".
+   *
+   * @param current The current taxonomy class in the recursive cleaning.
+   */
+  cleanTaxonomyClass = (current: TaxonomyClass): TaxonomyClass => {
+
+    const currentOut = this.copyTaxonomyClass(current);
+    let subTaxs: Array<TaxonomyClass> = [];
+
+    if (current.subsets){
+      /* Copy all elements of the subtree which have a specific property. */
+      for (let tc of current.subsets) {
+
+        /* Copy non-plain taxonomy classes. */
+        if (! tc.id.endsWith("_plain") ) {
+          subTaxs.push(this.cleanTaxonomyClass(tc));
+        }
+
+      }
+    }
+
+    currentOut.subsets = subTaxs;
+    return currentOut;
+  }
 
 }
 


### PR DESCRIPTION
# Overview
<!-- Briefly describe what this PR does. -->

This PR will resolve #65.

## Changes
<!-- List the main changes in this PR. -->

Added a recursive function that creates a taxonomy class tree that does not contain the "_plain" id EDAM entries.
I did not filter by label `_p` since this suffix is defined by restAPE. Instead, I used the EDAM URI suffixes which seems more stable to me.

## Testing
<!-- Describe how you tested your changes. -->

Tested it on the institutional instance at UP.

## Checklist

- [ ] Code follows project standards.
- [x] Self-reviewed and commented where needed.
- [x] Documentation updated if needed.
- [x] No new warnings or errors.