### PR TITLE
fix: Add nowrap to for white-space to benchmark values. Fixes: #66

### DIFF
--- a/src/components/benchmark/VisualizeBenchmarks.css
+++ b/src/components/benchmark/VisualizeBenchmarks.css
@@ -3,6 +3,7 @@
   margin: 5px;
   padding: 6px 24px;
   border-radius: 10px;
+  white-space: nowrap;
 }
 
 table.benchmark-results td {


### PR DESCRIPTION
# Overview

This PR fixes an issue where benchmark values were wrapping across multiple lines. By forcing the text to stay on a single line, the readability of the benchmark results is improved. Resolves issue #66.

## Changes

- Added `white-space: nowrap;` property to the CSS rules in `.../VisualizeBenchmarks.css` to prevent benchmark values from wrapping.

## Testing

- Visually reviewed in local environment that benchmark data values now correctly display on a single line without text wrapping within the tables.

## Checklist

- [x] Code follows project standards.
- [x] Self-reviewed and commented where needed.
- [x] Documentation updated if needed.
- [x] No new warnings or errors.